### PR TITLE
Switch-augeasproviders_grub-publisher

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,7 +1,7 @@
 fixtures:
   repositories:
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
-    augeasproviders_core: https://github.com/hercules-team/augeasproviders_core.git
-    augeasproviders_grub: https://github.com/hercules-team/augeasproviders_grub.git
+    augeasproviders_core: https://github.com/voxpupuli/puppet-augeasproviders_core.git
+    augeasproviders_grub: https://github.com/voxpupuli/puppet-augeasproviders_grub.git
   symlinks:
     kdump: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -13,8 +13,8 @@
       "version_requirement": ">= 4.13.0 <9.0.0"
     },
     {
-      "name": "herculesteam/augeasproviders_grub",
-      "version_requirement": ">= 2.3.1 <4.0.0"
+      "name": "puppet/augeasproviders_grub",
+      "version_requirement": ">= 2.3.1 <6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Switch from herculesteam to puppet for augeasproviders_grub due to deprecation of the former module

Fixes #19 