### PR TITLE
Fix merge function stdlib deprecation message

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,7 +88,7 @@ class kdump (
     'force_rebuild'     => 'UNSET',
   }
 
-  $config = stdlib::merge($config_defaults, $config_overrides)
+  $config = $config_defaults + $config_overrides
 
   if $enable {
     if $facts['crashkernel'] {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,7 +88,7 @@ class kdump (
     'force_rebuild'     => 'UNSET',
   }
 
-  $config = merge($config_defaults, $config_overrides)
+  $config = stdlib::merge($config_defaults, $config_overrides)
 
   if $enable {
     if $facts['crashkernel'] {


### PR DESCRIPTION
Fix 'This function is deprecated, please use stdlib::merge instead' warning message